### PR TITLE
change semantics for invalid residuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# 0.3.0
+
+- change semantics of infeasible results ([#14](https://github.com/tpapp/TrustRegionMethods.jl/pull/14))
+- minor fixes
+
 # 0.2.0
 
 - improve heuristic for singular Jacobians in dogleg ([#5](https://github.com/tpapp/TrustRegionMethods.jl/pull/5))

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TrustRegionMethods"
 uuid = "14486370-d344-40f0-8ff9-262f8a3330be"
 authors = ["Tamas K. Papp <tkpapp@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Experimental Julia package for trust region methods, with an emphasis on
 
 3. *AD agnostic function evaluations*: an objective function just returns a value with properties `residual` and `Jacobian`. It can be any type that supports this, and carry extra payload relevant to your problem. However, if you just want to code an ℝⁿ → ℝⁿ function, it can do AD for you using wrappers (currently `ForwardDiff`).
 
-4. *Support for bailing out*: some inputs just may not be possible or worthwhile to evaluated for very complicated functions (eg economic models). You can signal this by returning `nothing`.
+4. *Support for bailing out*: some inputs just may not be possible or worthwhile to evaluated for very complicated functions (eg economic models). You can signal this by returning non-finite residuals (eg `NaN`s).
 
 ## Example
 

--- a/src/TrustRegionMethods.jl
+++ b/src/TrustRegionMethods.jl
@@ -400,7 +400,7 @@ $(TYPEDEF)
 
 $(FIELDS)
 """
-struct TrustRegionResult{T,TX,TFX}
+struct TrustRegionResult{T<:Real,TX<:AbstractVector{T},TFX}
     "The final trust region radius."
     Δ::T
     "The last value (the root only when converged)."
@@ -413,6 +413,12 @@ struct TrustRegionResult{T,TX,TFX}
     converged::Bool
     "Number of iterations (≈ number of function evaluations)."
     iterations::Int
+end
+
+function TrustRegionResult(Δ::T1, x::AbstractVector{T2}, fx, residual_norm::T3, converged,
+                           iterations) where {T1 <: Real, T2 <: Real, T3 <: Real}
+    T = promote_type(T1, T2, T3)
+    TrustRegionResult(T(Δ), T.(x), fx, T(residual_norm), converged, iterations)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", trr::TrustRegionResult)
@@ -455,6 +461,7 @@ function trust_region_solver(f, x;
                              stopping_criterion = SolverStoppingCriterion(),
                              maximum_iterations = 500,
                              Δ = 1.0)
+    @argcheck Δ > 0
     fx = f(x)
     iterations = 1
     while true

--- a/src/TrustRegionMethods.jl
+++ b/src/TrustRegionMethods.jl
@@ -81,12 +81,15 @@ Return three values:
 2. the (Euclidean) *norm* of `pC`
 
 3. a boolean indicating whether the constraint was binding.
+
+Caller guarantees non-zero gradient.
 """
 function cauchy_point(Δ::Real, model::ResidualModel)
     @unpack r, J = model
     g = J' * r
     q = g' * (J' * J) * g
     g_norm = norm(g, 2)
+    @argcheck g_norm > 0
     τ = if q ≤ 0              # practically 0 (semi-definite form) but allow for float error
         one(q)
     else

--- a/src/TrustRegionMethods.jl
+++ b/src/TrustRegionMethods.jl
@@ -332,8 +332,6 @@ $(SIGNATURES)
 Ratio between predicted (using `model`, at `p`) and actual reduction (taken from the
 residual value `r′`). Will return an arbitrary negative number for infeasible coordinates.
 """
-reduction_ratio(fx, p, ::Nothing) = -one(eltype(p))
-
 function reduction_ratio(model::ResidualModel, p, r′)
     @unpack r, J = model
     r2 = sum(abs2, r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,25 +5,5 @@ import Optim
 global_logger(SimpleLogger(stdout, Logging.Debug))
 
 include("test_building_blocks.jl")
-
-@testset "linear problem" begin
-    for _ in 1:100
-        n = rand(2:10)
-        J = randn(n, n)
-        x0 = randn(n)
-        b = J * x0
-        for l in (Dogleg(), )
-            @show l
-            res = trust_region_solver(x -> (residual = J * x .- b, Jacobian = J), x0 .* 1000,
-                                      local_method = l)
-            @test res.x ≈ x0 atol = √eps() * n
-            @test norm(res.fx.residual, 2) ≈ 0 atol = √eps()
-            @test norm(res.fx.residual, 2) == res.residual_norm
-            @test res.fx.Jacobian == J
-            @test res.converged == true
-            display(res)
-        end
-    end
-end
-
+include("test_simple_problems.jl")
 include("test_nonlinear_problems.jl")

--- a/test/test_building_blocks.jl
+++ b/test/test_building_blocks.jl
@@ -133,7 +133,7 @@ end
 
     @testset "handle infeasible" begin
         ff = ForwardDiff_wrapper(x -> all(x .> 0) ? x : x .+ NaN, 4)
-        @test ff(-ones(4)) ≡ nothing
+        @test !all(isfinite, ff(-ones(4)).residual)
         @test ff(ones(4)) == (residual = ones(4), Jacobian = Diagonal(ones(4)))
     end
 end

--- a/test/test_building_blocks.jl
+++ b/test/test_building_blocks.jl
@@ -143,4 +143,5 @@ end
     @test repr(ff) isa AbstractString
     res = trust_region_solver(ff, ones(2))
     @test repr(res) isa AbstractString
+    @test repr(TrustRegionResult(1, [1.0], nothing, 1.0, false, 99)) isa AbstractString
 end

--- a/test/test_building_blocks.jl
+++ b/test/test_building_blocks.jl
@@ -110,14 +110,14 @@ end
 
 @testset "singularities" begin
     # just some basic sanity check to see if the solver can deal with these
-    singular_model = ResidualModel(ones(2), ones(2, 2))
+    singular1 = ResidualModel(ones(2), ones(2, 2))
     Δ = 1.0
-    @test is_consistent_solver_results(Δ, cauchy_point(1.0, singular_model)...)
-    @test is_consistent_solver_results(Δ, solve_model(Dogleg(), 1.0, singular_model)...)
+    @test is_consistent_solver_results(Δ, cauchy_point(1.0, singular1)...)
+    @test is_consistent_solver_results(Δ, solve_model(Dogleg(), 1.0, singular1)...)
     # FIXME: solver below could do better, just that hard case is not implemented.
     # check for that when it is.
-    @test is_consistent_solver_results(Δ, solve_model(GeneralizedEigenSolver(),
-                                                      1.0, singular_model)...)
+    @test is_consistent_solver_results(Δ, solve_model(GeneralizedEigenSolver(), 1.0,
+                                                      singular1)...)
 end
 
 @testset "ForwardDiff wrapper" begin

--- a/test/test_simple_problems.jl
+++ b/test/test_simple_problems.jl
@@ -1,0 +1,33 @@
+#####
+##### simple problems for testing
+#####
+
+@testset "linear problem" begin
+    for _ in 1:100
+        n = rand(2:10)
+        J = randn(n, n)
+        x0 = randn(n)
+        b = J * x0
+        for l in (Dogleg(), )
+            @show l
+            result = trust_region_solver(x -> (residual = J * x .- b, Jacobian = J),
+                                         x0 .* 1000, local_method = l)
+            @test result.x ≈ x0 atol = √eps() * n
+            @test norm(result.fx.residual, 2) ≈ 0 atol = √eps()
+            @test norm(result.fx.residual, 2) == result.residual_norm
+            @test result.fx.Jacobian == J
+            @test result.converged
+            display(result)
+        end
+    end
+end
+
+@testset "infeasible region" begin
+    # the solution x = 0 is infeasible, but do we get close?
+    function f(x)
+        (residual = x[1] ≥ 1 ? x : x .+ NaN, Jacobian = Diagonal(ones(length(x))))
+    end
+    result = trust_region_solver(f, [3.0])
+    @test !result.converged
+    @test result.x ≈ [1.0]
+end


### PR DESCRIPTION
Instead of `nothing`, use non-finite values.

Incidental changes:

- fix factorization for Diagonal
- fix constructor conversion for results
- add tests for infeasible region
- add docstrings